### PR TITLE
change commit hash by tag so it is easier to read

### DIFF
--- a/com.github.chipmuenk.pyfda.yaml
+++ b/com.github.chipmuenk.pyfda.yaml
@@ -14,6 +14,11 @@ finish-args:
   - --socket=fallback-x11
   - --device=dri
   - --persist=.pyfda # so the configuration of different installations will not be overwritten
+
+Parameters:
+  git_url: &git_url https://github.com/chipmuenk/pyfda.git
+  git_tag: &git_tag v0.7.1
+
 modules:
   - pyqt5.json
 
@@ -367,5 +372,5 @@ modules:
       - install -Dm755 pyfda/images/icons/pyfda_icon.svg /app/share/icons/hicolor/scalable/apps/pyfda_icon.svg
     sources:
       - type: git
-        url: https://github.com/chipmuenk/pyfda.git
-        tag: v0.7.1
+        url: *git_url
+        tag: *git_tag

--- a/com.github.chipmuenk.pyfda.yaml
+++ b/com.github.chipmuenk.pyfda.yaml
@@ -368,4 +368,4 @@ modules:
     sources:
       - type: git
         url: https://github.com/chipmuenk/pyfda.git
-        tag: v0.6.2
+        tag: v0.7.1

--- a/com.github.chipmuenk.pyfda.yaml
+++ b/com.github.chipmuenk.pyfda.yaml
@@ -368,4 +368,4 @@ modules:
     sources:
       - type: git
         url: https://github.com/chipmuenk/pyfda.git
-        commit: 5634b05fffb8b04791b7846a6cc7da195456a90d
+        tag: v0.6.2


### PR DESCRIPTION
@chipmuenk as soon as you create a new version of pyfda, lets say 0.6.2 we can change the versioning from commit: xx to tag: xx, so it gets easier to track